### PR TITLE
Adding CAN-FD bootloader support as well?

### DIFF
--- a/bootloader.c
+++ b/bootloader.c
@@ -1041,7 +1041,7 @@ void bootloader( void )
         service USB
         */
 
-        while( USB_Service() );
+        while( USB_Service() && CAN_Service() );
     }
 
 #if 0 ///< @todo Set protection from malicious user apps


### PR DESCRIPTION
Hello, I was hoping to ask you a question about how this bootloader works. I have a project that I'd like to be able to program via a USB port as well as over CAN-FD when it's built into a robot. I found your fork of this DFU bootloader which supports the SAMD51--my project uses the SAME51, which I think is identical except for the added CAN-FD hardware. I wanted to see if you think that this structure (essentially polling for CAN & USB alternatingly) would work.

Do you think this is the best way to insert another hardware programming protocol?

Thank you!